### PR TITLE
Enable ARM builds on Freescale i.MX6 boards

### DIFF
--- a/bin/dashman.sh
+++ b/bin/dashman.sh
@@ -94,7 +94,7 @@ case "$1" in
             _get_versions
             _check_dashd_running
             ok " ${messages["done"]}"
-            if [ ! -z "$RPI" ] && [ $RPI2 -eq 0 ]; then
+            if [ ! -z "$ARM" ] && [ $BIGARM -eq 0 ]; then
                 die "$COMMAND not supported yet on this platform."
             fi
             update_dashd
@@ -105,7 +105,7 @@ case "$1" in
             _check_dashman_updates
             _get_versions
             ok " ${messages["done"]}"
-            if [ ! -z "$RPI" ] && [ $RPI2 -eq 0 ]; then
+            if [ ! -z "$ARM" ] && [ $BIGARM -eq 0 ]; then
                 die "$COMMAND not supported yet on this platform."
             fi
             if [ ! -z "$2" ]; then
@@ -129,7 +129,7 @@ case "$1" in
             _check_dashd_running
             REINSTALL=1
             ok " ${messages["done"]}"
-            if [ ! -z "$RPI" ] && [ $RPI2 -eq 0 ]; then
+            if [ ! -z "$ARM" ] && [ $BIGARM -eq 0 ]; then
                 die "$COMMAND not supported yet on this platform."
             fi
             update_dashd

--- a/lib/dashman_functions.sh
+++ b/lib/dashman_functions.sh
@@ -239,8 +239,8 @@ _get_platform_info() {
             ;;
         armv7l)
             BITS=32
-            RPI=1
-            RPI2=$(grep BCM2709 /proc/cpuinfo | wc -l)
+            ARM=1
+            BIGARM=$(grep -E "(BCM2709|Freescale i\\.MX6)" /proc/cpuinfo | wc -l)
             ;;
         *)
             err "${messages["err_unknown_platform"]} $PLATFORM"
@@ -255,7 +255,7 @@ _get_versions() {
     DOWNLOAD_HTML=$( $curl_cmd $DOWNLOAD_PAGE )
     local IFS=' '
     DOWNLOAD_FOR='linux'
-    if [ ! -z "$RPI2" ]; then
+    if [ ! -z "$BIGARM" ]; then
         DOWNLOAD_FOR='RPi2'
     fi
     read -a DOWNLOAD_URLS <<< $( echo $DOWNLOAD_HTML | sed -e 's/ /\n/g' | grep binaries | grep Download | grep $DOWNLOAD_FOR | perl -ne '/.*"([^"]+)".*/; print "$1 ";' 2>/dev/null )


### PR DESCRIPTION
I decided I wanted to try running Dash on the [CuBox-i4x4](https://www.solid-run.com/product/cubox-i4x4/) computer I bought a while back, but dashman wouldn't install the ARM build on it because it's not a Raspberry Pi 2.

The board in this device identifies itself as:

> Hardware	: Freescale i.MX6 Quad/DualLite (Device Tree)

I've added a hacky patch to trick dashman into installing it. This isn't a scalable system for adding more boards, but it works on my machine!