### PR TITLE
add -L to curl_cmd for redirects

### DIFF
--- a/lib/dashman_functions.sh
+++ b/lib/dashman_functions.sh
@@ -24,7 +24,7 @@ else
     DASHMAN_CHECKOUT=" ("$DASHMAN_CHECKOUT")"
 fi
 
-curl_cmd='timeout 7 curl -s'
+curl_cmd='timeout 7 curl -s -L'
 
 # (mostly) functioning functions -- lots of refactoring to do ----------------
 


### PR DESCRIPTION
This fixes a problem where an old api url causes 301 from nginx. Using `-L` with curl makes curl retry on the moved host.

More concretely. The following url was used:

`https://dashninja.pl/api/masternodes?ips=\["x.y.z.w:9999"\]&portcheck=1&balance=1`

When the new url is `https://www.dashninja.pl/api..`